### PR TITLE
Fix code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/backend/routes/transactions.js
+++ b/backend/routes/transactions.js
@@ -1,10 +1,16 @@
 const router = require('express').Router();
 const { addIncome, getIncome, deleteIncome } = require('../controllers/income');
 const { addExpense, getExpense, deleteExpense } = require('../controllers/expense');
+const rateLimit = require('express-rate-limit');
+
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+});
 
 router
     .post('/addincome', addIncome)
-    .get('/getincome', getIncome)
+    .get('/getincome', limiter, getIncome)
     .delete('/deleteincome/:id', deleteIncome)
     .post('/addexpense', addExpense)
     .get('/getexpense', getExpense)


### PR DESCRIPTION
Fixes [https://github.com/gnpthbalaji/expense-tracker/security/code-scanning/2](https://github.com/gnpthbalaji/expense-tracker/security/code-scanning/2)

To fix the problem, we need to introduce rate limiting to the `getIncome` route handler to prevent potential denial-of-service attacks. The best way to achieve this is by using the `express-rate-limit` middleware, which allows us to set a maximum number of requests that can be made to the route within a specified time window.

We will:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `backend/routes/transactions.js` file.
3. Set up a rate limiter with appropriate configuration.
4. Apply the rate limiter to the `getIncome` route handler.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
