### PR TITLE
Fix code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/backend/routes/transactions.js
+++ b/backend/routes/transactions.js
@@ -11,7 +11,7 @@ const limiter = rateLimit({
 router
     .post('/addincome', addIncome)
     .get('/getincome', limiter, getIncome)
-    .delete('/deleteincome/:id', deleteIncome)
+    .delete('/deleteincome/:id', limiter, deleteIncome)
     .post('/addexpense', addExpense)
     .get('/getexpense', getExpense)
     .delete('/deleteexpense/:id', deleteExpense);


### PR DESCRIPTION
Fixes [https://github.com/gnpthbalaji/expense-tracker/security/code-scanning/3](https://github.com/gnpthbalaji/expense-tracker/security/code-scanning/3)

To fix the problem, we need to apply the rate limiter middleware to the `deleteIncome` route. This will ensure that the number of requests to this route is limited, thereby reducing the risk of denial-of-service attacks. We will use the existing rate limiter `limiter` that is already defined in the code.

We will modify the `router` definition to include the `limiter` middleware for the `deleteIncome` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
