### PR TITLE
Fix code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/backend/routes/transactions.js
+++ b/backend/routes/transactions.js
@@ -13,7 +13,7 @@ router
     .get('/getincome', limiter, getIncome)
     .delete('/deleteincome/:id', limiter, deleteIncome)
     .post('/addexpense', addExpense)
-    .get('/getexpense', getExpense)
-    .delete('/deleteexpense/:id', deleteExpense);
+    .get('/getexpense', limiter, getExpense)
+    .delete('/deleteexpense/:id', limiter, deleteExpense);
 
 module.exports = router;


### PR DESCRIPTION
Fixes [https://github.com/gnpthbalaji/expense-tracker/security/code-scanning/4](https://github.com/gnpthbalaji/expense-tracker/security/code-scanning/4)

To fix the problem, we need to apply the rate limiter middleware to the `getExpense` route handler. This will ensure that the number of requests to this route is limited, preventing potential denial-of-service attacks.

The best way to fix the problem without changing existing functionality is to add the `limiter` middleware to the `getExpense` route handler, similar to how it is already applied to the `getIncome` and `deleteIncome` route handlers.

We need to make the following changes in the `backend/routes/transactions.js` file:
- Apply the `limiter` middleware to the `getExpense` route handler.
- Apply the `limiter` middleware to the `deleteExpense` route handler for consistency and to ensure all routes performing database access are rate-limited.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
