### PR TITLE
Fix code scanning alert no. 7: Database query built from user-controlled sources

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -10,7 +10,7 @@ exports.registerUser = async (req, res) => {
     const { name, email, password } = req.body;
 
     // Check if user already exists
-    const existingUser = await User.findOne({ email });
+    const existingUser = await User.findOne({ email: { $eq: email } });
     if (existingUser) {
       return res.status(400).json({ message: 'User already exists' });
     }
@@ -40,7 +40,7 @@ exports.loginUser = async (req, res) => {
     const { email, password } = req.body;
 
     // Check if user exists
-    const user = await User.findOne({ email });
+    const user = await User.findOne({ email: { $eq: email } });
     if (!user) {
       return res.status(400).json({ message: 'Invalid email or password' });
     }


### PR DESCRIPTION
Fixes [https://github.com/gnpthbalaji/expense-tracker/security/code-scanning/7](https://github.com/gnpthbalaji/expense-tracker/security/code-scanning/7)

To fix the problem, we need to ensure that the `email` value is treated as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. This will ensure that the `email` value is interpreted as a literal string and not as a query object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
